### PR TITLE
fix(rfc3164): handle message with date in brackets

### DIFF
--- a/src/rfc3164.rs
+++ b/src/rfc3164.rs
@@ -3,7 +3,7 @@ use crate::{
     message::{Message, Protocol},
     parsers::{hostname, tagname},
     pri::pri,
-    structured_data::structured_data_strict,
+    structured_data::structured_data_optional,
     timestamp::{timestamp_3164, IncompleteDate},
 };
 use chrono::prelude::*;
@@ -74,7 +74,7 @@ where
             opt(space0),
             opt(tag(":")),
             opt(space0),
-            opt(structured_data_strict),
+            opt(structured_data_optional(false)),
             opt(space0),
             rest,
         )),

--- a/src/rfc3164.rs
+++ b/src/rfc3164.rs
@@ -3,7 +3,7 @@ use crate::{
     message::{Message, Protocol},
     parsers::{hostname, tagname},
     pri::pri,
-    structured_data::structured_data,
+    structured_data::structured_data_strict,
     timestamp::{timestamp_3164, IncompleteDate},
 };
 use chrono::prelude::*;
@@ -74,7 +74,7 @@ where
             opt(space0),
             opt(tag(":")),
             opt(space0),
-            opt(structured_data),
+            opt(structured_data_strict),
             opt(space0),
             rest,
         )),
@@ -289,6 +289,33 @@ mod tests {
                     msgid: None,
                     structured_data: vec![],
                     msg: "a message",
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn parse_3164_3339_datetime_in_message() {
+        assert_eq!(
+            parse(
+                "<131>Jun 8 11:54:08 master apache_error [Tue Jun 08 11:54:08.929301 2021] [php7:emerg] [pid 1374899] [client 95.223.77.60:41888] rest of message",
+                |_| { 2021 },
+                None
+            )
+            .unwrap(),
+            (
+                "",
+                Message {
+                    protocol: Protocol::RFC3164,
+                    facility: Some(SyslogFacility::LOG_LOCAL0),
+                    severity: Some(SyslogSeverity::SEV_ERR),
+                    timestamp: Some(FixedOffset::west(0).ymd(2021, 6, 8).and_hms(9, 54, 8)),
+                    hostname: Some("master"),
+                    appname: Some("apache_error"),
+                    procid: None,
+                    msgid: None,
+                    structured_data: vec![],
+                    msg: "[Tue Jun 08 11:54:08.929301 2021] [php7:emerg] [pid 1374899] [client 95.223.77.60:41888] rest of message",
                 }
             )
         );

--- a/src/rfc3164.rs
+++ b/src/rfc3164.rs
@@ -300,7 +300,7 @@ mod tests {
             parse(
                 "<131>Jun 8 11:54:08 master apache_error [Tue Jun 08 11:54:08.929301 2021] [php7:emerg] [pid 1374899] [client 95.223.77.60:41888] rest of message",
                 |_| { 2021 },
-                None
+                Some(Utc.fix())
             )
             .unwrap(),
             (
@@ -309,7 +309,7 @@ mod tests {
                     protocol: Protocol::RFC3164,
                     facility: Some(SyslogFacility::LOG_LOCAL0),
                     severity: Some(SyslogSeverity::SEV_ERR),
-                    timestamp: Some(FixedOffset::west(0).ymd(2021, 6, 8).and_hms(9, 54, 8)),
+                    timestamp: Some(FixedOffset::west(0).ymd(2021, 6, 8).and_hms(11, 54, 8)),
                     hostname: Some("master"),
                     appname: Some("apache_error"),
                     procid: None,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -219,7 +219,7 @@ fn parse_3164_no_tag() {
             msgid: None,
             protocol: Protocol::RFC3164,
             structured_data: vec![],
-            msg: "start",
+            msg: "[software=\"rsyslogd\" swVersion=\"8.32.0\" x-pid=\"20506\" x-info=\"http://www.rsyslog.com\"] start",
         }
     );
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -198,7 +198,7 @@ fn parse_3164_invalid_structured_data() {
             msgid: None,
             protocol: Protocol::RFC3164,
             structured_data: vec![],
-            msg: "start",
+            msg: "[software=\"rsyslogd\" swVersion=\"8.32.0\" x-pid=\"20506\" x-info=\"http://www.rsyslog.com\"] start",
         }
     );
 }


### PR DESCRIPTION
fixes #11 by keeping the values that cannot be decoded.

Signed-off-by: Jérémie Drouet <jeremie.drouet@datadoghq.com>