### PR TITLE
Added variant parameter to specify which variant we should parse as.

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -5,6 +5,7 @@ use criterion::{BenchmarkId, Criterion, Throughput};
 use criterion_cycles_per_byte::CyclesPerByte;
 use std::convert::TryInto;
 use std::include_str;
+use syslog_loose::Variant;
 
 struct Parameter<'a> {
     line: &'a str,
@@ -39,7 +40,7 @@ fn parse_bench_rfc5424(c: &mut Criterion<CyclesPerByte>) {
 
         group.throughput(Throughput::Bytes(bytes));
         group.bench_with_input(BenchmarkId::new(name, bytes), line, |b, line| {
-            b.iter(|| syslog_loose::parse_message(&line))
+            b.iter(|| syslog_loose::parse_message(&line, Variant::Either))
         });
     }
     group.finish();

--- a/examples/parser/main.rs
+++ b/examples/parser/main.rs
@@ -1,12 +1,12 @@
 // This program spins in a busy loop, calling `parse_message` on a static bit of
 // text. This is done to interrogate the performance of `parse_message` with
 // tools like [flamegraph](https://github.com/flamegraph-rs/flamegraph).
-use syslog_loose::Message;
+use syslog_loose::{Message, Variant};
 
 fn main() {
     let log: &str = "<165>1 2003-10-11T22:14:15.003Z mymachine.example.com evntslog - ID47 [exampleSDID@32473 iut=\"3\" eventSource= \"Application\" eventID=\"1011\"] BOMAn application event log entry...";
 
     loop {
-        let _: Message<&str> = syslog_loose::parse_message(log);
+        let _: Message<&str> = syslog_loose::parse_message(log, Variant::Either);
     }
 }

--- a/examples/server/main.rs
+++ b/examples/server/main.rs
@@ -2,6 +2,7 @@ extern crate syslog_loose;
 
 use chrono::prelude::*;
 use std::net::UdpSocket;
+use syslog_loose::Variant;
 
 fn resolve_year((month, _date, _hour, _min, _sec): syslog_loose::IncompleteDate) -> i32 {
     let now = Utc::now();
@@ -22,7 +23,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("{}", line);
         println!(
             "{:#?}",
-            syslog_loose::parse_message_with_year(&line, resolve_year)
+            syslog_loose::parse_message_with_year(&line, resolve_year, Variant::Either)
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ where
             alt((rfc5424::parse, |input| rfc3164::parse(input, get_year, tz)))(input.trim())
         }
         Variant::RFC3164 => rfc3164::parse(input.trim(), get_year, tz),
-        Variant::RFC5424 => rfc5424::parse(input),
+        Variant::RFC5424 => rfc5424::parse(input.trim()),
     }
 }
 

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -10,7 +10,9 @@ use non_empty_string::{
     ValueString,
 };
 use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
-use syslog_loose::{decompose_pri, parse_message, Message, ProcId, Protocol, StructuredElement};
+use syslog_loose::{
+    decompose_pri, parse_message, Message, ProcId, Protocol, StructuredElement, Variant,
+};
 
 /// Create a wrapper struct for us to implement Arbitrary against
 #[derive(Clone, Debug)]
@@ -235,7 +237,7 @@ fn inner_parses_generated_messages(msg: Wrapper<Message<String>>) -> TestResult 
     let text = format!("{}", msg);
 
     // Parse it.
-    let parsed: Message<&str> = parse_message(&text);
+    let parsed: Message<&str> = parse_message(&text, Variant::Either);
     let parsed = parsed.into();
     let result = msg == parsed;
 


### PR DESCRIPTION
Fixes #20.

This adds a new parameter `variant` to the parse functions to specify which variant we are expecting. 

`Variant::Either` will attempt both formats. If you know which format you are expecting you can pass `Variant::RFC3164` or `Variant::RFC5424` to parse as that which can save processing.