### PR TITLE
Disable oldtime feature of chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 nom = "7.1"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 
 [dev-dependencies]
 chrono-tz = "0.5"


### PR DESCRIPTION
`chrono` enables the `oldtime` feature for backwards compatibility but this project doesn't make use of it. Disabling it avoids the dependency on `time` v0.1