### PR TITLE
Remove structured data from rfc3164 

### DIFF
--- a/src/rfc3164.rs
+++ b/src/rfc3164.rs
@@ -326,7 +326,7 @@ mod tests {
     fn parse_3164_no_structured_data() {
         assert_eq!(
             parse::<_, Local>(
-                "2024-09-19T15:39:45.469435+02:00 node1234 slurmstepd[548422]: [65684352.batch] done with job",
+                "2024-09-19T15:39:45+02:00 node1234 slurmstepd[548422]: [65684352.batch] done with job",
                 |_| { 2019 },
                 None
             )
@@ -338,9 +338,9 @@ mod tests {
                     facility: None,
                     severity: None,
                     timestamp: Some(
-                        FixedOffset::west_opt(0)
+                        FixedOffset::west_opt(-2 * 3600)
                             .unwrap()
-                            .with_ymd_and_hms(2024, 9, 19, 17, 39, 45)
+                            .with_ymd_and_hms(2024, 9, 19, 15, 39, 45)
                             .unwrap()
                     ),
                     hostname: Some("node1234"),

--- a/src/rfc3164.rs
+++ b/src/rfc3164.rs
@@ -78,11 +78,9 @@ where
             opt(space0),
             opt(tag(":")),
             opt(space0),
-            opt(structured_data_optional(false)),
-            opt(space0),
             rest,
         )),
-        |(pri, _, timestamp, field1, field2, _, _, _, structured_data, _, msg)| {
+        |(pri, _, timestamp, field1, field2, _, _, _, msg)| {
             let (host, appname, pid) = resolve_host_and_tag(field1, field2);
 
             Message {
@@ -94,7 +92,7 @@ where
                 appname,
                 procid: pid.map(|p| p.into()),
                 msgid: None,
-                structured_data: structured_data.unwrap_or_default(),
+                structured_data: vec![],
                 msg,
             }
         },

--- a/src/rfc3164.rs
+++ b/src/rfc3164.rs
@@ -82,8 +82,6 @@ where
         |(pri, _, timestamp, field1, field2, _, _, _, msg)| {
             let (host, appname, pid) = resolve_host_and_tag(field1, field2);
 
-            println!("XXX: parsing RFC3164 style message, msg is {}", msg);
-
             Message {
                 protocol: Protocol::RFC3164,
                 facility: pri.0,

--- a/src/rfc3164.rs
+++ b/src/rfc3164.rs
@@ -323,6 +323,38 @@ mod tests {
     }
 
     #[test]
+    fn parse_3164_no_structured_data() {
+        assert_eq!(
+            parse::<_, Local>(
+                "2024-09-19T15:39:45.469435+02:00 node1234 slurmstepd[548422]: [65684352.batch] done with job",
+                |_| { 2019 },
+                None
+            )
+            .unwrap(),
+            (
+                "",
+                Message {
+                    protocol: Protocol::RFC3164,
+                    facility: None,
+                    severity: None,
+                    timestamp: Some(
+                        FixedOffset::west_opt(0)
+                            .unwrap()
+                            .with_ymd_and_hms(2024, 9, 19, 17, 39, 45)
+                            .unwrap()
+                    ),
+                    hostname: Some("node1234"),
+                    appname: Some("slurmstepd"),
+                    procid: Some(ProcId::PID(548422)),
+                    msgid: None,
+                    structured_data: vec![],
+                    msg: "[65684352.batch] done with job",
+                }
+            )
+        );
+    }
+
+    #[test]
     fn parse_3164_3339_datetime_in_message() {
         assert_eq!(
             parse::<_, FixedOffset>(

--- a/src/rfc3164.rs
+++ b/src/rfc3164.rs
@@ -3,7 +3,6 @@ use crate::{
     message::{Message, Protocol},
     parsers::{hostname, tagname},
     pri::pri,
-    structured_data::structured_data_optional,
     timestamp::{timestamp_3164, IncompleteDate},
 };
 use chrono::prelude::*;
@@ -82,6 +81,8 @@ where
         )),
         |(pri, _, timestamp, field1, field2, _, _, _, msg)| {
             let (host, appname, pid) = resolve_host_and_tag(field1, field2);
+
+            println!("XXX: parsing RFC3164 style message, msg is {}", msg);
 
             Message {
                 protocol: Protocol::RFC3164,
@@ -327,7 +328,7 @@ mod tests {
         assert_eq!(
             parse::<_, Local>(
                 "2024-09-19T15:39:45+02:00 node1234 slurmstepd[548422]: [65684352.batch] done with job",
-                |_| { 2019 },
+                |_| { 2024 },
                 None
             )
             .unwrap(),


### PR DESCRIPTION
I don't think this does what you'd like according to the comment in #37, it just forces to adhere to the RFC, i.e., no structured data.