### PR TITLE
Handle Empty structured data in 3164

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -1,4 +1,4 @@
-use crate::pri::{compose_pri, SyslogFacility, SyslogSeverity};
+use crate::pri::{SyslogFacility, SyslogSeverity, compose_pri};
 use crate::procid::ProcId;
 use crate::structured_data;
 use chrono::prelude::*;

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -1,10 +1,10 @@
 //! Parsers shared by both protocols.
 use nom::{
+    Err, IResult, Parser as _,
     bytes::complete::take_while1,
     character::complete::digit1,
     combinator::map_res,
-    error::{make_error, ErrorKind},
-    Err, IResult, Parser as _,
+    error::{ErrorKind, make_error},
 };
 use std::str::FromStr;
 

--- a/src/pri.rs
+++ b/src/pri.rs
@@ -1,5 +1,10 @@
 use crate::parsers::digits;
-use nom::{bytes::complete::tag, combinator::{map, opt}, sequence::delimited, IResult, Parser as _};
+use nom::{
+    IResult, Parser as _,
+    bytes::complete::tag,
+    combinator::{map, opt},
+    sequence::delimited,
+};
 
 // Taken from https://github.com/Roguelazer/rust-syslog-rfc5424/blob/af76363081314f91433e014c76fd834acef756d5/src/facility.rs
 // Many thanks.
@@ -174,7 +179,8 @@ pub(crate) fn pri(input: &str) -> IResult<&str, (Option<SyslogFacility>, Option<
     map(
         opt(delimited(tag("<"), map(digits, decompose_pri), tag(">"))),
         |pri| pri.unwrap_or((None, None)),
-    ).parse(input)
+    )
+    .parse(input)
 }
 
 #[test]

--- a/src/rfc3164.rs
+++ b/src/rfc3164.rs
@@ -75,7 +75,7 @@ where
             opt(space0),
             opt(tag(":")),
             opt(space0),
-            opt(structured_data_optional(false)),
+            opt(structured_data_optional),
             opt(space0),
             rest,
         ),

--- a/src/rfc3164.rs
+++ b/src/rfc3164.rs
@@ -8,7 +8,11 @@ use crate::{
 };
 use chrono::prelude::*;
 use nom::{
-    bytes::complete::{is_not, tag, take_while}, character::complete::space0, combinator::{map, opt, rest}, sequence::{delimited, preceded}, IResult, Parser as _
+    IResult, Parser as _,
+    bytes::complete::{is_not, tag, take_while},
+    character::complete::space0,
+    combinator::{map, opt, rest},
+    sequence::{delimited, preceded},
 };
 
 // Parse the tag - a process name followed by a pid in [].
@@ -95,7 +99,8 @@ where
                 msg,
             }
         },
-    ).parse(input)
+    )
+    .parse(input)
 }
 
 #[test]

--- a/src/rfc5424.rs
+++ b/src/rfc5424.rs
@@ -7,7 +7,9 @@ use crate::{
     timestamp::timestamp_3339,
 };
 use nom::{
-    character::complete::{space0, space1}, combinator::{map, rest}, IResult, Parser as _
+    IResult, Parser as _,
+    character::complete::{space0, space1},
+    combinator::{map, rest},
 };
 
 /// Parse the version number - just a simple integer.
@@ -65,7 +67,8 @@ pub(crate) fn parse(input: &str) -> IResult<&str, Message<&str>> {
             structured_data,
             msg,
         },
-    ).parse(input)
+    )
+    .parse(input)
 }
 
 #[cfg(test)]

--- a/src/structured_data.rs
+++ b/src/structured_data.rs
@@ -1,10 +1,10 @@
 use nom::{
-    IResult, Mode, Parser,
+    IResult, Parser,
     branch::alt,
     bytes::complete::{escaped, tag, take_till1, take_until, take_while1},
     character::complete::{anychar, space0},
     combinator::map,
-    error::{self, ParseError},
+    error,
     multi::{many1, separated_list0},
     sequence::{delimited, separated_pair, terminated},
 };
@@ -202,14 +202,14 @@ impl StructuredDatumParser {
             self.structured_datum_strict(input)
         }?;
 
-	// 3164 often has items that look like structured data, but isn't.
-	// Generally, stuff between square brackets that doesn't follow a
-	// [id key=value] pattern. This would get parsed as an empty StructuredElement
-	// with no parameters. In this case, we want to return an error instead
-	// so that it is treated as invalid structured data and incorporated into the
-	// message.
-	// In 5424 structured data without any parameters is perfectly valid, so 
-	// needs it returned as a success.
+        // 3164 often has items that look like structured data, but isn't.
+        // Generally, stuff between square brackets that doesn't follow a
+        // [id key=value] pattern. This would get parsed as an empty StructuredElement
+        // with no parameters. In this case, we want to return an error instead
+        // so that it is treated as invalid structured data and incorporated into the
+        // message.
+        // In 5424 structured data without any parameters is perfectly valid, so
+        // needs it returned as a success.
         if !self.allow_empty
             && result
                 .as_ref()

--- a/src/structured_data.rs
+++ b/src/structured_data.rs
@@ -1,5 +1,12 @@
 use nom::{
-    branch::alt, bytes::complete::{escaped, tag, take_till1, take_until, take_while1}, character::complete::{anychar, space0}, combinator::map, multi::{many1, separated_list0}, sequence::{delimited, separated_pair, terminated}, IResult, Parser as _
+    IResult, Mode, Parser,
+    branch::alt,
+    bytes::complete::{escaped, tag, take_till1, take_until, take_while1},
+    character::complete::{anychar, space0},
+    combinator::map,
+    error::{self, ParseError},
+    multi::{many1, separated_list0},
+    sequence::{delimited, separated_pair, terminated},
 };
 use std::fmt;
 
@@ -117,7 +124,8 @@ fn param_value(input: &str) -> IResult<&str, &str> {
             escaped(take_while1(|c: char| c != '\\' && c != '"'), '\\', anychar),
             tag("\""),
         ),
-    )).parse(input)
+    ))
+    .parse(input)
 }
 
 /// Parse a param name="value"
@@ -126,63 +134,121 @@ fn param(input: &str) -> IResult<&str, (&str, &str)> {
         take_till1(|c: char| c == ']' || c == '='),
         terminated(tag("="), space0),
         param_value,
-    ).parse(input)
-}
-
-/// Parse a single structured data record.
-/// [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"]
-fn structured_datum_strict(input: &str) -> IResult<&str, Option<StructuredElement<&str>>> {
-    delimited(
-        tag("["),
-        map(
-            (
-                take_till1(|c: char| c.is_whitespace() || c == ']' || c == '='),
-                space0,
-                separated_list0(tag(" "), param),
-            ),
-            |(id, _, params)| Some(StructuredElement { id, params }),
-        ),
-        tag("]"),
-    ).parse(input)
-}
-
-/// Parse a single structured data record allowing anything between brackets.
-fn structured_datum_permissive(input: &str) -> IResult<&str, Option<StructuredElement<&str>>> {
-    alt((
-        structured_datum_strict,
-        // If the element fails to parse, just parse it and return None.
-        delimited(tag("["), map(take_until("]"), |_| None), tag("]")),
-    )).parse(input)
+    )
+    .parse(input)
 }
 
 /// Parse a single structured data record.
 fn structured_datum(
     allow_failure: bool,
+    allow_empty: bool,
 ) -> impl FnMut(&str) -> IResult<&str, Option<StructuredElement<&str>>> {
-    if allow_failure {
-        structured_datum_permissive
-    } else {
-        structured_datum_strict
+    move |input| {
+        StructuredDatumParser {
+            allow_failure,
+            allow_empty,
+        }
+        .parse(input)
     }
+}
+
+struct StructuredDatumParser {
+    allow_failure: bool,
+    allow_empty: bool,
+}
+
+impl StructuredDatumParser {
+    /// Parse a single structured data record.
+    /// [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"]
+    fn structured_datum_strict<'a>(
+        &self,
+        input: &'a str,
+    ) -> IResult<&'a str, Option<StructuredElement<&'a str>>> {
+        delimited(
+            tag("["),
+            map(
+                (
+                    take_till1(|c: char| c.is_whitespace() || c == ']' || c == '='),
+                    space0,
+                    separated_list0(tag(" "), param),
+                ),
+                |(id, _, params)| Some(StructuredElement { id, params }),
+            ),
+            tag("]"),
+        )
+        .parse(input)
+    }
+
+    /// Parse a single structured data record allowing anything between brackets.
+    fn structured_datum_permissive<'a>(
+        &self,
+        input: &'a str,
+    ) -> IResult<&'a str, Option<StructuredElement<&'a str>>> {
+        alt((
+            |input| self.structured_datum_strict(input),
+            // If the element fails to parse, just parse it and return None.
+            delimited(tag("["), map(take_until("]"), |_| None), tag("]")),
+        ))
+        .parse(input)
+    }
+
+    pub(crate) fn parse<'a>(
+        &mut self,
+        input: &'a str,
+    ) -> IResult<&'a str, Option<StructuredElement<&'a str>>> {
+        let (remaining, result) = if self.allow_failure {
+            self.structured_datum_permissive(input)
+        } else {
+            self.structured_datum_strict(input)
+        }?;
+
+	// 3164 often has items that look like structured data, but isn't.
+	// Generally, stuff between square brackets that doesn't follow a
+	// [id key=value] pattern. This would get parsed as an empty StructuredElement
+	// with no parameters. In this case, we want to return an error instead
+	// so that it is treated as invalid structured data and incorporated into the
+	// message.
+	// In 5424 structured data without any parameters is perfectly valid, so 
+	// needs it returned as a success.
+        if !self.allow_empty
+            && result
+                .as_ref()
+                .map_or(false, |element| element.params.len() == 0)
+        {
+            Err(nom::Err::Error(error::Error::new(
+                input,
+                error::ErrorKind::Fail,
+            )))
+        } else {
+            Ok((remaining, result))
+        }
+    }
+}
+
+/// Parse multiple structured data elements.
+fn parse_structured_data<'a>(
+    allow_failure: bool,
+    allow_empty: bool,
+    input: &'a str,
+) -> IResult<&'a str, Vec<StructuredElement<&'a str>>> {
+    alt((
+        map(tag("-"), |_| vec![]),
+        map(
+            many1(structured_datum(allow_failure, allow_empty)),
+            |items| items.iter().filter_map(|item| item.clone()).collect(),
+        ),
+    ))
+    .parse(input)
 }
 
 /// Parse multiple structured data elements.
 pub(crate) fn structured_data(input: &str) -> IResult<&str, Vec<StructuredElement<&str>>> {
-    structured_data_optional(true)(input)
+    parse_structured_data(true, true, input)
 }
 
 /// Parse multiple structured data elements.
-pub(crate) fn structured_data_optional(
-    allow_failure: bool,
-) -> impl FnMut(&str) -> IResult<&str, Vec<StructuredElement<&str>>> {
-    move |input| {
-        alt((
-            map(tag("-"), |_| vec![]),
-            map(many1(structured_datum(allow_failure)), |items| {
-                items.iter().filter_map(|item| item.clone()).collect()
-            }),
-        )).parse(input)
-    }
+pub(crate) fn structured_data_optional(input: &str) -> IResult<&str, Vec<StructuredElement<&str>>> {
+    parse_structured_data(false, false, input)
 }
 
 #[cfg(test)]
@@ -205,9 +271,11 @@ mod tests {
     #[test]
     fn parse_structured_data() {
         assert_eq!(
-            structured_datum_strict(
-                "[exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"]"
-            )
+            StructuredDatumParser {
+                allow_empty: false,
+                allow_failure: true,
+            }
+            .parse("[exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"]")
             .unwrap(),
             (
                 "",
@@ -226,7 +294,7 @@ mod tests {
     #[test]
     fn parse_structured_data_no_values() {
         assert_eq!(
-            structured_datum(false)("[exampleSDID@32473]").unwrap(),
+            structured_datum(false, true)("[exampleSDID@32473]").unwrap(),
             (
                 "",
                 Some(StructuredElement {
@@ -240,7 +308,7 @@ mod tests {
     #[test]
     fn parse_structured_data_with_space() {
         assert_eq!(
-            structured_datum(false)(
+            structured_datum(false, true)(
                 "[exampleSDID@32473 iut=\"3\" eventSource= \"Application\" eventID=\"1011\"]"
             )
             .unwrap(),
@@ -261,7 +329,7 @@ mod tests {
     #[test]
     fn parse_invalid_structured_data() {
         assert_eq!(
-            structured_datum(true)("[exampleSDID@32473 iut=]"),
+            structured_datum(true, true)("[exampleSDID@32473 iut=]"),
             Ok(("", None))
         );
     }
@@ -296,17 +364,8 @@ mod tests {
     }
 
     #[test]
-    fn parse_structured_data_keep_invalid_elements() {
-        assert_eq!(
-            structured_data_optional(false)("[abc][id aa=]").unwrap(),
-            (
-                "[id aa=]",
-                vec![StructuredElement {
-                    id: "abc",
-                    params: vec![],
-                },]
-            )
-        )
+    fn parse_structured_data_dont_keep_empty_elements() {
+        assert!(structured_data_optional("[abc] message").is_err())
     }
 
     #[test]
@@ -375,5 +434,21 @@ bye"#
 
         let (_, value) = param_value(r#""These should not be escaped -> \n\m\o""#).unwrap();
         assert_eq!(r#"These should not be escaped -> \n\m\o"#, value);
+    }
+
+    #[test]
+    fn parse_empty_structured_data() {
+        assert_eq!(
+            structured_datum(true, true)("[WAN_LOCAL-default-D]"),
+            Ok((
+                "",
+                Some(StructuredElement {
+                    id: "WAN_LOCAL-default-D",
+                    params: vec![]
+                })
+            ))
+        );
+
+        assert!(structured_datum(true, false)("[WAN_LOCAL-default-D]").is_err());
     }
 }

--- a/tests/non_empty_string.rs
+++ b/tests/non_empty_string.rs
@@ -1,10 +1,6 @@
 use quickcheck::{Arbitrary, Gen};
 use std::num::NonZeroU8;
 
-trait FilterChars {
-    fn valid(c: char) -> bool;
-}
-
 fn gen_string<F>(g: &mut Gen, valid_char: F) -> String
 where
     F: Fn(char) -> bool,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,16 +1,12 @@
-use chrono::{prelude::*, Duration};
+use chrono::{Duration, prelude::*};
 use syslog_loose::{
-    parse_message, parse_message_with_year, parse_message_with_year_exact,
-    parse_message_with_year_exact_tz, IncompleteDate, Message, ProcId, Protocol, StructuredElement,
-    SyslogFacility, SyslogSeverity, Variant,
+    IncompleteDate, Message, ProcId, Protocol, StructuredElement, SyslogFacility, SyslogSeverity,
+    Variant, parse_message, parse_message_with_year, parse_message_with_year_exact,
+    parse_message_with_year_exact_tz,
 };
 
 fn with_year((month, _date, _hour, _min, _sec): IncompleteDate) -> i32 {
-    if month == 12 {
-        2019
-    } else {
-        2020
-    }
+    if month == 12 { 2019 } else { 2020 }
 }
 
 #[test]
@@ -23,7 +19,12 @@ fn parse_nginx() {
         Message {
             facility: Some(SyslogFacility::LOG_LOCAL7),
             severity: Some(SyslogSeverity::SEV_INFO),
-            timestamp: Some(Local.with_ymd_and_hms(2019, 12, 28,16, 49, 7).unwrap().into()),
+            timestamp: Some(
+                Local
+                    .with_ymd_and_hms(2019, 12, 28, 16, 49, 7)
+                    .unwrap()
+                    .into()
+            ),
             hostname: Some("plertrood-thinkpad-x220"),
             appname: Some("nginx"),
             procid: None,
@@ -270,7 +271,12 @@ fn parse_3164_invalid_structured_data() {
         Message {
             facility: Some(SyslogFacility::LOG_SYSLOG),
             severity: Some(SyslogSeverity::SEV_INFO),
-            timestamp: Some(Local.with_ymd_and_hms(2020, 1, 5, 15, 33, 3).unwrap().into()),
+            timestamp: Some(
+                Local
+                    .with_ymd_and_hms(2020, 1, 5, 15, 33, 3)
+                    .unwrap()
+                    .into()
+            ),
             hostname: Some("plertrood-ThinkPad-X220"),
             appname: Some("rsyslogd"),
             procid: None,
@@ -291,7 +297,12 @@ fn parse_3164_no_tag() {
         Message {
             facility: Some(SyslogFacility::LOG_SYSLOG),
             severity: Some(SyslogSeverity::SEV_INFO),
-            timestamp: Some(Local.with_ymd_and_hms(2020, 1, 5,15, 33, 3).unwrap().into()),
+            timestamp: Some(
+                Local
+                    .with_ymd_and_hms(2020, 1, 5, 15, 33, 3)
+                    .unwrap()
+                    .into()
+            ),
             hostname: Some("plertrood-ThinkPad-X220"),
             appname: None,
             procid: None,
@@ -723,8 +734,11 @@ fn logical_system_juniper_routers() {
             facility: Some(SyslogFacility::LOG_DAEMON),
             severity: Some(SyslogSeverity::SEV_WARNING),
             timestamp: Some(
-                FixedOffset::west_opt(1800 * 6).unwrap()
-                    .with_ymd_and_hms(2020, 5, 22,14, 59, 9).unwrap() + Duration::microseconds(250000)
+                FixedOffset::west_opt(1800 * 6)
+                    .unwrap()
+                    .with_ymd_and_hms(2020, 5, 22, 14, 59, 9)
+                    .unwrap()
+                    + Duration::microseconds(250000)
             ),
             hostname: Some("OX-XXX-MX204"),
             appname: Some("OX-XXX-CONTEUDO:rpd"),
@@ -746,7 +760,12 @@ fn parse_missing_pri() {
         Message {
             facility: None,
             severity: None,
-            timestamp: Some(Local.with_ymd_and_hms(2019, 12, 28,16, 49, 7).unwrap().into()),
+            timestamp: Some(
+                Local
+                    .with_ymd_and_hms(2019, 12, 28, 16, 49, 7)
+                    .unwrap()
+                    .into()
+            ),
             hostname: Some("plertrood-thinkpad-x220"),
             appname: Some("nginx"),
             procid: None,
@@ -768,8 +787,11 @@ fn parse_missing_pri_5424() {
             facility: None,
             severity: None,
             timestamp: Some(
-                FixedOffset::west_opt(1800 * 6).unwrap()
-                    .with_ymd_and_hms(2020, 5, 22,14, 59, 9).unwrap() + Duration::microseconds(250000)
+                FixedOffset::west_opt(1800 * 6)
+                    .unwrap()
+                    .with_ymd_and_hms(2020, 5, 22, 14, 59, 9)
+                    .unwrap()
+                    + Duration::microseconds(250000)
             ),
             hostname: Some("OX-XXX-MX204"),
             appname: Some("OX-XXX-CONTEUDO:rpd"),
@@ -899,4 +921,31 @@ fn parse_ipv6_hostname() {
         },
         parse_message(msg, Variant::RFC5424)
     )
+}
+
+#[test]
+fn parse_3164_ubnt_iptables() {
+    // Can 3164 parse ok when there is something looking similar to structured data - but not quite.
+    let msg = "<4>Jan 26 05:59:54 ubnt kernel: [WAN_LOCAL-default-D]IN=eth0 OUT= MAC=b4:fb:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:08:00 SRC=135.148.25.121 DST=xxx.xxx.xxx.xxx LEN=60 TOS=0x00 PREC=0x00 TTL=46 ID=59401 DF PROTO=TCP SPT=46146 DPT=4433 WINDOW=5840 RES=0x00 SYN URGP=0";
+
+    assert_eq!(
+        parse_message_with_year(msg, with_year, Variant::Either),
+        Message {
+            facility: Some(SyslogFacility::LOG_KERN),
+            severity: Some(SyslogSeverity::SEV_WARNING),
+            timestamp: Some(
+                Local
+                    .with_ymd_and_hms(2020, 1, 26, 5, 59, 54)
+                    .unwrap()
+                    .into()
+            ),
+            hostname: Some("ubnt"),
+            appname: Some("kernel"),
+            procid: None,
+            msgid: None,
+            protocol: Protocol::RFC3164,
+            structured_data: vec![],
+            msg: "[WAN_LOCAL-default-D]IN=eth0 OUT= MAC=b4:fb:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:08:00 SRC=135.148.25.121 DST=xxx.xxx.xxx.xxx LEN=60 TOS=0x00 PREC=0x00 TTL=46 ID=59401 DF PROTO=TCP SPT=46146 DPT=4433 WINDOW=5840 RES=0x00 SYN URGP=0",
+        }
+    );
 }


### PR DESCRIPTION
Fixes #37.

Messages such as 

```
<4>Jan 26 05:59:54 ubnt kernel: [WAN_LOCAL-default-D]IN=eth0 OUT= MAC=b4:fb:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:08:00 SRC=135.148.25.121 DST=xxx.xxx.xxx.xxx LEN=60 TOS=0x00 PREC=0x00 TTL=46 ID=59401 DF PROTO=TCP SPT=46146 DPT=4433 WINDOW=5840 RES=0x00 SYN URGP=0
```

contains what looks like structured data `[WAN_LOCAL-default-D]`, but is not structured data.

Unfortunately some 3164 messages do contain structured data, so this PR compromises by saying structured data without parameters should not be treated as structured data. This should capture the cases where 3164 messages should not be treated as having structured data.